### PR TITLE
Use .git on github addresses for circleci - it replaces https with ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "third_party/requests-futures"]
 	path = third_party/requests-futures
-	url = https://github.com/ross/requests-futures
+	url = https://github.com/ross/requests-futures.git
 [submodule "third_party/ycmd"]
 	path = third_party/ycmd
-	url = https://github.com/Valloric/ycmd
+	url = https://github.com/Valloric/ycmd.git
 [submodule "third_party/python-future"]
 	path = third_party/python-future
-	url = https://github.com/PythonCharmers/python-future
+	url = https://github.com/PythonCharmers/python-future.git
 [submodule "third_party/frozendict"]
 	path = third_party/frozendict
-	url = https://github.com/slezica/python-frozendict/
+	url = https://github.com/slezica/python-frozendict.git
 [submodule "third_party/requests"]
 	path = third_party/requests
-	url = https://github.com/requests/requests/
+	url = https://github.com/requests/requests.git
 [submodule "third_party/protoycmd"]
 	path = third_party/protoycmd
-	url = https://github.com/bstaletic/protoycmd
+	url = https://github.com/bstaletic/protoycmd.git


### PR DESCRIPTION
CircleCI uses the following `.gitconfig`:

```
[url "ssh://git@github.com"]
        insteadOf = https://github.com
```

This tells git "replace all `https://github.com` with `ssh://git@github.com`". Ostensibly this is so that it uses the SSH keys for all GitHub repo authentication, as the cost (it would seem) of simplicity and it-just-works for public repos. 

I suppose CircleCI is commercial and priority is commercial repos so this makes some sense.

For some reason I don't understand, some GitHub repos will only clone via ssh when then have the `.git` suffix, i.e.:

* FAILS: `BenMBP:tmp ben$ git clone ssh://git@github.com/slezica/python-frozendict/`
* SUCCEEDS: `BenMBP:tmp ben$ git clone ssh://git@github.com/slezica/python-frozendict.git`
* SUCCEEDS: `BenMBP:tmp ben$ git clone https://github.com/slezica/python-frozendict/`
* SUCCEEDS: `BenMBP:tmp ben$ git clone https://github.com/slezica/python-frozendict.git`


So the solution is to append the `.git` in the submodule path. This works for both https and ssh.
