### PR TITLE
Improve popup UX

### DIFF
--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -26,6 +26,11 @@ let s:lines_and_handles = v:none
 let s:select = -1
 let s:kind = ''
 
+let s:ingored_keys = [
+      \ "\<CursorHold>",
+      \ "\<MouseMove>",
+      \ ]
+
 function! youcompleteme#hierarchy#StartRequest( kind )
   py3 ycm_state.ResetCurrentHierarchy()
   if a:kind == 'call'
@@ -43,30 +48,30 @@ function! youcompleteme#hierarchy#StartRequest( kind )
     let s:lines_and_handles = lines_and_handles
     let s:kind = a:kind
     let s:select = 1
-    call s:SetupMenu()
+    call s:SetUpMenu()
   endif
 endfunction
 
 function! s:MenuFilter( winid, key )
   if a:key == "\<S-Tab>"
     let will_change_root = s:lines_and_handles[ s:select - 1 ][ 1 ] > 0
-    call popup_close( s:popup_id, [ s:select - 1, 'resolve_up', will_change_root ] )
+    call popup_close(
+          \ s:popup_id,
+          \ [ s:select - 1, 'resolve_up', will_change_root ] )
     return 1
   endif
   if a:key == "\<Tab>"
     let will_change_root = s:lines_and_handles[ s:select - 1 ][ 1 ] < 0
-    call popup_close( s:popup_id, [ s:select - 1, 'resolve_down', will_change_root ] )
-    return 1
-  endif
-  if a:key == "\<Esc>"
-    call popup_close( s:popup_id, [ s:select - 1, 'cancel', v:none ] )
+    call popup_close(
+          \ s:popup_id,
+          \ [ s:select - 1, 'resolve_down', will_change_root ] )
     return 1
   endif
   if a:key == "\<CR>"
     call popup_close( s:popup_id, [ s:select - 1, 'jump', v:none ] )
     return 1
   endif
-  if a:key == "\<Up>"
+  if a:key == "\<Up>" || a:key == "\<C-p>" || a:key == "\<C-k>" || a:key == "k"
     let s:select -= 1
     if s:select < 1
       let s:select = 1
@@ -75,13 +80,21 @@ function! s:MenuFilter( winid, key )
                     \ 'call cursor( [' . string( s:select ) . ', 1 ] )' )
     return 1
   endif
-  if a:key == "\<Down>"
+  if a:key == "\<Down>" || a:key == "\<C-n>" || a:key == "\<C-j>" || a:key == "j"
     let s:select += 1
     if s:select > len( s:lines_and_handles )
       let s:select = len( s:lines_and_handles )
     endif
     call win_execute( s:popup_id,
                     \ 'call cursor( [' . string( s:select ) . ', 1 ] )' )
+    return 1
+  endif
+  if index( s:ingored_keys, a:key ) >= 0
+    return 0
+  endif
+  " Close the popup on any other key press
+  call popup_close( s:popup_id, [ s:select - 1, 'cancel', v:none ] )
+  if a:key == "\<Esc>" || a:key == "\<C-c>"
     return 1
   endif
   return 0
@@ -105,14 +118,15 @@ function! s:MenuCallback( winid, result )
   endif
 endfunction
 
-function! s:SetupMenu()
+function! s:SetUpMenu()
   let menu_lines = []
   for line_and_item in s:lines_and_handles
     call add( menu_lines, line_and_item[ 0 ] )
   endfor
   let s:popup_id = popup_menu( menu_lines, #{
-    \ filter: funcref( 's:MenuFilter' ),
-    \ callback: funcref( 's:MenuCallback' ) } )
+    \   filter: funcref( 's:MenuFilter' ),
+    \   callback: funcref( 's:MenuCallback' )
+    \ } )
   call win_execute( s:popup_id,
                   \ 'call cursor( [' . string( s:select ) . ', 1 ] )' )
 endfunction
@@ -127,10 +141,11 @@ function! s:ResolveItem( choice, direction, will_change_root )
         \ 'vim.eval( "a:direction" ) )' )
     let s:lines_and_handles = lines_and_handles_with_offset[ 0 ]
     if a:will_change_root
-      let s:select = 1 + indexof( s:lines_and_handles, { i, v -> v[0][0] =~ "[-+]" } )
+      let s:select = 1 + indexof( s:lines_and_handles,
+            \                     { i, v -> v[0][0] =~ "[-+]" } )
     else
       let s:select += lines_and_handles_with_offset[ 1 ]
     endif
   endif
-  call s:SetupMenu()
+  call s:SetUpMenu()
 endfunction

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -100,18 +100,32 @@ class HierarchyTree:
       kind = next_node._data[ 'kind' ]
       if use_down_nodes:
         partial_result.extend( [
-          ( ' ' * indent + symbol + kind + ': ' + name + 3 * '\t' +
-              os.path.split( l[ 'filepath' ] )[ 1 ] + ':' +
-              str( l[ 'line_num' ] ) + 3 * '\t' + l.get( 'description', '' ),
-            ( i * 1000000 + j ) )
-          for j, l in enumerate( next_node._data[ 'locations' ] ) ] )
+          (
+            {
+              'indent': indent,
+              'icon': symbol,
+              'symbol': kind + ': ' + name,
+              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ] + ':' + str( l[ 'line_num' ] ),
+              'description': l.get( 'description', '' ),
+            },
+            i * 1000000 + j
+          )
+          for j, l in enumerate( next_node._data[ 'locations' ] )
+        ] )
       else:
         partial_result.extend( [
-          ( ' ' * indent + symbol + kind + ': ' + name + 3 * '\t' +
-              os.path.split( l[ 'filepath' ] )[ 1 ] + ':' +
-              str( l[ 'line_num' ] ) + 3 * '\t' + l.get( 'description', '' ),
-            ( i * 1000000 + j ) * -1 )
-          for j, l in enumerate( next_node._data[ 'locations' ] ) ] )
+          (
+            {
+              'indent': indent,
+              'icon': symbol,
+              'symbol': kind + ': ' + name,
+              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ] + ':' + str( l[ 'line_num' ] ),
+              'description': l.get( 'description', '' ),
+            },
+            ( i * 1000000 + j ) * -1
+          )
+          for j, l in enumerate( next_node._data[ 'locations' ] )
+        ] )
       if next_node._references:
         partial_result.extend(
           self._HierarchyToLinesHelper(


### PR DESCRIPTION
This makes the popup disappear if you keep typing or enter inser mode or move the cursor etc.

I found it jarring that previously it would just move the cursor behind the popup and such until you hit escape. Makes the popup more "modal" but without actually stopping you from continueing.

Also:

- Use simliar up/down keys as the symbol finder (c-p, c-k, c-n, c-j etc.)
- SetupFoo -> SetUpFoo because the verb is "To set up" (rather than the noun "a setup".
- purge barbaric 80+ character lines

