### PR TITLE
Style the hierarchy popup like the finder popup

### DIFF
--- a/autoload/youcompleteme/finder.vim
+++ b/autoload/youcompleteme/finder.vim
@@ -113,35 +113,6 @@ scriptencoding utf-8
 " The other functions are utility for the most part and handle things like
 " TextChangedI event, starting/stopping drawing the spinner and such.
 
-let s:highlight_group_for_symbol_kind = {
-      \ 'Array': 'Identifier',
-      \ 'Boolean': 'Boolean',
-      \ 'Class': 'Structure',
-      \ 'Constant': 'Constant',
-      \ 'Constructor': 'Function',
-      \ 'Enum': 'Structure',
-      \ 'EnumMember': 'Identifier',
-      \ 'Event': 'Identifier',
-      \ 'Field': 'Identifier',
-      \ 'Function': 'Function',
-      \ 'Interface': 'Structure',
-      \ 'Key': 'Identifier',
-      \ 'Method': 'Function',
-      \ 'Module': 'Include',
-      \ 'Namespace': 'Type',
-      \ 'Null': 'Keyword',
-      \ 'Number': 'Number',
-      \ 'Object': 'Structure',
-      \ 'Operator': 'Operator',
-      \ 'Package': 'Include',
-      \ 'Property': 'Identifier',
-      \ 'String': 'String',
-      \ 'Struct': 'Structure',
-      \ 'TypeParameter': 'Typedef',
-      \ 'Variable': 'Identifier',
-      \ }
-let s:initialized_text_properties = v:false
-
 let s:icon_spinner = [ '/', '-', '\', '|', '/', '-', '\', '|' ]
 let s:icon_done = 'X'
 let s:spinner_delay = 100
@@ -156,18 +127,7 @@ function! youcompleteme#finder#FindSymbol( scope ) abort
     return
   endif
 
-  if !s:initialized_text_properties
-    call prop_type_add( 'YCM-symbol-Normal', { 'highlight': 'Normal' } )
-    for k in keys( s:highlight_group_for_symbol_kind )
-      call prop_type_add(
-            \ 'YCM-symbol-' . k,
-            \ { 'highlight': s:highlight_group_for_symbol_kind[ k ] } )
-    endfor
-    call prop_type_add( 'YCM-symbol-file', { 'highlight': 'Comment' } )
-    call prop_type_add( 'YCM-symbol-filetype', { 'highlight': 'Special' } )
-    call prop_type_add( 'YCM-symbol-line-num', { 'highlight': 'Number' } )
-    let s:initialized_text_properties = v:true
-  endif
+  call youcompleteme#symbol#InitSymbolProperties()
 
   let s:find_symbol_status = {
         \ 'selected': -1,
@@ -470,11 +430,7 @@ function! s:RedrawFinderPopup() abort
         let kind = result[ 'extra_data' ][ 'kind' ]
         let name = result[ 'extra_data' ][ 'name' ]
         let desc = kind .. ': ' .. name
-        if s:highlight_group_for_symbol_kind->has_key( kind )
-          let prop = 'YCM-symbol-' . kind
-        else
-          let prop = 'YCM-symbol-Normal'
-        endif
+        let prop = youcompleteme#symbol#GetPropForSymbolKind( kind )
         let props = [
             \ { 'col': 1,
             \   'length': len( kind ) + 2,

--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -144,7 +144,7 @@ function! s:SetUpMenu()
     \   border: [],
     \ }
   if &ambiwidth ==# 'single' && &encoding ==? 'utf-8'
-    let opts[ 'borderchars' ] = [ '─', '│', '─', '│', '╭', '╮', '┛', '╰' ]
+    let opts[ 'borderchars' ] = [ '─', '│', '─', '│', '╭', '╮', '╯', '╰' ]
   endif
 
   let s:popup_id = popup_create( [], opts )

--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -157,6 +157,9 @@ function! s:SetUpMenu()
           \ .. item.icon
           \ .. item.kind
           \ .. ': ' .. item.symbol
+    " -2 because:
+    "   0-based index
+    "   1 for the tab character
     let trunc_name = name[ : tabstop - 2 ]
     let props = []
     let name_pfx_len = len( indent ) + len( item.icon ) + len( item.kind ) + 2
@@ -193,7 +196,6 @@ function! s:SetUpMenu()
 
     let trunc_desc = item.description[ : tabstop - 2 ]
 
-    " TODO: Explain (understand) why it's -2 not -1 for the space (padding?)
     let line = trunc_name
           \ . "\t"
           \ .. trunc_path

--- a/autoload/youcompleteme/symbol.vim
+++ b/autoload/youcompleteme/symbol.vim
@@ -1,0 +1,71 @@
+" Copyright (C) 2024 YouCompleteMe contributors
+"
+" This file is part of YouCompleteMe.
+"
+" YouCompleteMe is free software: you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation, either version 3 of the License, or
+" (at your option) any later version.
+"
+" YouCompleteMe is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+"
+" You should have received a copy of the GNU General Public License
+" along with YouCompleteMe.  If not, see <http://www.gnu.org/licenses/>.
+
+
+let s:highlight_group_for_symbol_kind = {
+      \ 'Array': 'Identifier',
+      \ 'Boolean': 'Boolean',
+      \ 'Class': 'Structure',
+      \ 'Constant': 'Constant',
+      \ 'Constructor': 'Function',
+      \ 'Enum': 'Structure',
+      \ 'EnumMember': 'Identifier',
+      \ 'Event': 'Identifier',
+      \ 'Field': 'Identifier',
+      \ 'Function': 'Function',
+      \ 'Interface': 'Structure',
+      \ 'Key': 'Identifier',
+      \ 'Method': 'Function',
+      \ 'Module': 'Include',
+      \ 'Namespace': 'Type',
+      \ 'Null': 'Keyword',
+      \ 'Number': 'Number',
+      \ 'Object': 'Structure',
+      \ 'Operator': 'Operator',
+      \ 'Package': 'Include',
+      \ 'Property': 'Identifier',
+      \ 'String': 'String',
+      \ 'Struct': 'Structure',
+      \ 'TypeParameter': 'Typedef',
+      \ 'Variable': 'Identifier',
+      \ }
+let s:initialized_text_properties = v:false
+
+function! youcompleteme#symbol#InitSymbolProperties() abort
+  if !s:initialized_text_properties
+    call prop_type_add( 'YCM-symbol-Normal', { 'highlight': 'Normal' } )
+    for k in keys( s:highlight_group_for_symbol_kind )
+      call prop_type_add(
+            \ 'YCM-symbol-' . k,
+            \ { 'highlight': s:highlight_group_for_symbol_kind[ k ] } )
+    endfor
+    call prop_type_add( 'YCM-symbol-file', { 'highlight': 'Comment' } )
+    call prop_type_add( 'YCM-symbol-filetype', { 'highlight': 'Special' } )
+    call prop_type_add( 'YCM-symbol-line-num', { 'highlight': 'Number' } )
+    let s:initialized_text_properties = v:true
+  endif
+endfunction
+
+function! youcompleteme#symbol#GetPropForSymbolKind( kind ) abort
+  if s:highlight_group_for_symbol_kind->has_key( a:kind )
+    return 'YCM-symbol-' . a:kind
+  endif
+
+  return 'YCM-symbol-Normal'
+endfunction
+
+

--- a/python/ycm/client/base_request.py
+++ b/python/ycm/client/base_request.py
@@ -308,6 +308,7 @@ def _BuildUri( handler ):
 
 
 def MakeServerException( data ):
+  _logger.debug( 'Server exception: %s', data )
   if data[ 'exception' ][ 'TYPE' ] == UnknownExtraConf.__name__:
     return UnknownExtraConf( data[ 'exception' ][ 'extra_conf_file' ] )
 

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -114,8 +114,10 @@ class HierarchyTree:
             {
               'indent': indent,
               'icon': symbol,
-              'symbol': kind + ': ' + name,
-              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ] + ':' + str( l[ 'line_num' ] ),
+              'symbol': name,
+              'kind': kind,
+              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ],
+              'line_num': str( l[ 'line_num' ] ),
               'description': l.get( 'description', '' ),
             },
             make_handle( index, location_index )
@@ -128,8 +130,10 @@ class HierarchyTree:
             {
               'indent': indent,
               'icon': symbol,
-              'symbol': kind + ': ' + name,
-              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ] + ':' + str( l[ 'line_num' ] ),
+              'symbol': name,
+              'kind': kind,
+              'filepath': os.path.split( l[ 'filepath' ] )[ 1 ],
+              'line_num': str( l[ 'line_num' ] ),
               'description': l.get( 'description', '' ),
             },
             make_handle( index, location_index ) * -1

--- a/python/ycm/hierarchy_tree.py
+++ b/python/ycm/hierarchy_tree.py
@@ -118,7 +118,7 @@ class HierarchyTree:
               'kind': kind,
               'filepath': os.path.split( l[ 'filepath' ] )[ 1 ],
               'line_num': str( l[ 'line_num' ] ),
-              'description': l.get( 'description', '' ),
+              'description': l.get( 'description', '' ).strip(),
             },
             make_handle( index, location_index )
           )
@@ -134,7 +134,7 @@ class HierarchyTree:
               'kind': kind,
               'filepath': os.path.split( l[ 'filepath' ] )[ 1 ],
               'line_num': str( l[ 'line_num' ] ),
-              'description': l.get( 'description', '' ),
+              'description': l.get( 'description', '' ).strip(),
             },
             make_handle( index, location_index ) * -1
           )


### PR DESCRIPTION
This basically involves moving the properties mapping to its own place, and creating text properties to overlap the various parts of the popup columns. Style matches, and feels correct.

Fiddly part is that we have to (for some reason) set cursorline every time we move the cursor, but ain't nobody gonna be able to explain why, and why that only necessary after launching the finder popup window once. Some wierd vim bug is my guess.

demo https://asciinema.org/a/iZokOHjVSOh0yPdTpOjtKYTqJ