### PR TITLE
Fix vim tests for hierarchies

### DIFF
--- a/autoload/youcompleteme/hierarchy.vim
+++ b/autoload/youcompleteme/hierarchy.vim
@@ -233,8 +233,15 @@ function! s:ResolveItem( choice, direction, will_change_root )
       " where we _don't_ re-root the tree, so feels more natural than anything
       " else.
       " The new root is the element with indent of 0.
-      let s:select = 1 + indexof( s:lines_and_handles,
-            \                     { i, v -> v[0].indent == 0 } )
+      " let s:select = 1 + indexof( s:lines_and_handles,
+      "       \                     { i, v -> v[0].indent == 0 } )
+      let s:select = 1
+      for item in s:lines_and_handles
+        if item[0].indent == 0
+          break
+        endif
+        let s:select += 1
+      endfor
     else
       let s:select += lines_and_handles_with_offset[ 1 ]
     endif

--- a/test/hierarchies.test.vim
+++ b/test/hierarchies.test.vim
@@ -15,164 +15,136 @@ function! Test_Call_Hierarchy()
   call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/hierarchies.cc', {} )
   call cursor( [ 1, 5 ] )
 
-  " Check that f's callers are present
-  function! Check1( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
-    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Tab>", funcref( 'Check2' ) )
-  endfunction
-
-  " Check that g's callers are present
-  function! Check2( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^    +Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Down>\<Tab>", funcref( 'Check8' ) )
-  endfunction
-
-  " Check that 1st h's callers are present
-  function! Check3( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Tab>", funcref( 'Check4' ) )
-  endfunction
-
-  " Check that 2nd h's callers are present
-  function! Check4( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-    call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Up>\<Up>\<Up>\<Up>\<S-Tab>", funcref( 'Check5' ) )
-  endfunction
-
-  " Try to access callees of f
-  function! Check5( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-    call WaitForAssert( { -> assert_match( '^-Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Down>\<Down>\<Down>\<S-Tab>", funcref( 'Check6' ) )
-  endfunction
-
-  " Re-root at h
-  function! Check6( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
-    call WaitForAssert( { -> assert_match( '^+Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 ) ) } )
-    call FeedAndCheckAgain( "\<S-Tab>\<Tab>", funcref( 'Check7' ) )
-  endfunction
-
-  " Expansion after re-rooting works.
-  " NOTE: Clangd does not support outgoing calls, hence, we are stuck at just h.
-  function! Check7( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
-    call WaitForAssert( { -> assert_match( '^-Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 ) ) } )
-    call FeedAndCheckAgain( "\<C-c>", funcref( 'Check8' ) )
-  endfunction
-
-  " Make sure it is closed
-  function! Check8( id )
-    call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
-  endfunction
-
   call youcompleteme#hierarchy#StartRequest( 'call' )
   call WaitForAssert( { -> assert_equal( len( popup_list() ), 1 ) } )
   " Check that `+Function f` is at the start of the only line in the popup
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
   call WaitForAssert( { -> assert_match( '^+Function: f', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call FeedAndCheckMain( "\<Tab>", funcref( 'Check1' ) )
+
+  silent call feedkeys( "\<Tab>", "xt" )
+  " Check that f's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
+  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Tab>", "xt" )
+  " Check that g's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^    +Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Down>\<Tab>", "xt" )
+  " Check that 1st h's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Tab>", "xt" )
+  " Check that 2nd h's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+  call WaitForAssert( { -> assert_match( '^+Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Up>\<Up>\<Up>\<Up>\<S-Tab>", "xt" )
+  " Try to access callees of f
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
+  call WaitForAssert( { -> assert_match( '^-Function: f.*:1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: g.*:4', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^    -Function: h.*:8', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Function: h.*:9', getbufline( winbufnr( popup_list()[ 0 ] ), 5 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Down>\<Down>\<Down>\<S-Tab>", "xt" )
+  " Re-root at h
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
+  call WaitForAssert( { -> assert_match( '^+Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[0] ) } )
+
+  silent call feedkeys( "\<S-Tab>\<Tab>", "xt" )
+  " Expansion after re-rooting works.
+  " NOTE: Clangd does not support outgoing calls, hence, we are stuck at just h.
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
+  call WaitForAssert( { -> assert_match( '^-Function: h', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+
+  call feedkeys( "\<C-c>", "xt" )
+  " Make sure it is closed
+  call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
+
+  %bwipe!
 endfunction
 
 function! Test_Type_Hierarchy()
-  "call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/hierarchies.cc', {} )
+  call youcompleteme#test#setup#OpenFile( '/test/testdata/cpp/hierarchies.cc', {} )
   call cursor( [ 13, 8 ] )
-
-  " Check that B1's subtypes are present
-  function! Check1( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
-    call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Tab>", funcref( 'Check2' ) )
-  endfunction
-
-  " Try to access D1's subtypes
-  function! Check2( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
-    call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Up>\<S-Tab>", funcref( 'Check3' ) )
-  endfunction
-
-  " Check that 1st h's callers are present
-  function! Check3( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Up>\<S-Tab>", funcref( 'Check4' ) )
-  endfunction
-
-  " Check that 2nd h's callers are present
-  function! Check4( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
-    call WaitForAssert( { -> assert_match( '^  -Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Tab>", funcref( 'Check5' ) )
-  endfunction
-
-  " Re-root at B0: supertypes->subtypes
-  function! Check5( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 5 ) } )
-    call WaitForAssert( { -> assert_match( '^+Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: D0.*:15', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Down>\<Down>\<Down>\<S-Tab>", funcref( 'Check6' ) )
-  endfunction
-
-  " Re-root at D1: subtypes->supertypes
-  function! Check6( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^+Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<Tab>\<Up>\<S-Tab>", funcref( 'Check7' ) )
-  endfunction
-
-  " Expansion after re-rooting works.
-  function! Check7( id )
-    call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
-    call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^    +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^  -Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
-    call WaitForAssert( { -> assert_match( '^-Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
-    call FeedAndCheckAgain( "\<C-c>", funcref( 'Check7' ) )
-  endfunction
-
-  " Make sure it is closed
-  function! Check8( id )
-    call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
-  endfunction
 
   call youcompleteme#hierarchy#StartRequest( 'type' )
   call WaitForAssert( { -> assert_equal( len( popup_list() ), 1 ) } )
   " Check that `+Function f` is at the start of the only line in the popup
   call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 1 ) } )
   call WaitForAssert( { -> assert_match( '^+Struct: B1', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
-  call FeedAndCheckMain( "\<Tab>", funcref( 'Check1' ) )
+
+  silent call feedkeys( "\<Tab>", "xt" )
+  " Check that B1's subtypes are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
+  call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Tab>", "xt" )
+  " Try to access D1's subtypes
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 2 ) } )
+  call WaitForAssert( { -> assert_match( '^+Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Up>\<S-Tab>", "xt" )
+  " Check that 1st h's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Up>\<S-Tab>", "xt" )
+  " Check that 2nd h's callers are present
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
+  call WaitForAssert( { -> assert_match( '^  -Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^-Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Tab>", "xt" )
+  " Re-root at B0: supertypes->subtypes
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
+  call WaitForAssert( { -> assert_match( '^+Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: D0.*:15', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Down>\<Down>\<Down>\<S-Tab>", "xt" )
+  " Re-root at D1: subtypes->supertypes
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 3 ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^+Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+
+  silent call feedkeys( "\<Tab>\<Up>\<S-Tab>", "xt" )
+  " Expansion after re-rooting works.
+  call WaitForAssert( { -> assert_equal( len( getbufline( winbufnr( popup_list()[ 0 ] ), 1, '$' ) ), 4 ) } )
+  call WaitForAssert( { -> assert_match( '^  +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 1 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^    +Struct: B0.*:12', getbufline( winbufnr( popup_list()[ 0 ] ), 2 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^  -Struct: B1.*:13', getbufline( winbufnr( popup_list()[ 0 ] ), 3 )[ 0 ] ) } )
+  call WaitForAssert( { -> assert_match( '^-Struct: D1.*:16', getbufline( winbufnr( popup_list()[ 0 ] ), 4 )[ 0 ] ) } )
+
+  call feedkeys( "\<C-c>", "xt" )
+  " Make sure it is closed
+  call WaitForAssert( { -> assert_equal( len( popup_list() ), 0 ) } )
+
+  %bwipe!
 endfunction


### PR DESCRIPTION
Previously the tests were using async result checking, but this is intended for insert mode only. In fact we were running off the end of the test and then the check callbacks were firing.

Simplified by just making it the same but sequential, and replacding FeedAndCheck* with direct calls to feedkeys(..., 'xt').

